### PR TITLE
fix wildcard handling in SubTopic and PubTopic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,5 @@ package:
 	python setup.py bdist_wheel
 
 test:
-	coverage run -m pytest -vv --timeout 30
+	coverage run --source src -m pytest -vv --timeout 30
 	coverage html

--- a/src/topic.py
+++ b/src/topic.py
@@ -25,7 +25,7 @@ class Topic:
         """
         ret = '#'
         if self._keys:
-            ret = '#.%s.#' % '.#.'.join(sorted([str(key) for key in self._keys]))
+            ret = '#.%s.#' % '.#.'.join(sorted([str(key) for key in self._keys if str(key) != '#']))
         return ret
 
 
@@ -42,5 +42,9 @@ class PubTopic(Topic):
         Returns:
             str: Description
         """
-        ret = '.'.join(sorted([str(key) for key in self._keys]))
-        return ret
+        ret = []
+        keys = sorted([str(key) for key in self._keys])
+        for key in keys:
+            if not (key == "#" and key in ret):
+                ret.append(key)
+        return ".".join(ret)

--- a/test/unit/test_topic.py
+++ b/test/unit/test_topic.py
@@ -1,0 +1,31 @@
+import pytest
+from src.topic import SubTopic, PubTopic
+
+
+@pytest.mark.parametribe("raw, formatted", [
+    ("a.b.c", "a.b.c",),
+    ("c.b.a", "a.b.c"),
+    ("b.#.a", "#.a.b"),
+    ("b.*.a", "*.a.b"),
+    ("#.b.*.a.#", "#.*.a.b"),
+    ("", ""),
+    (None, ""),
+])
+def test_pubtopic(raw, formatted):
+    """assert that PubTopic.__str__ correctly reformats PubTopic._keys"""
+    assert str(PubTopic(raw)) == formatted
+
+
+@pytest.mark.parametribe("raw, formatted", [
+    ("a.b.c", "#.a.#.b.#.c.#",),
+    ("c.b.a", "#.a.#.b.#.c.#"),
+    ("b.#.a", "#.a.#.b.#"),
+    ("b.*.a", "#.*.#.a.#.b.#"),
+    ("b.*.a.*", "#.*.#.*.#.a.#.b.#"),
+    ("#.b.*.a.#", "#.*.#.a.#.b.#"),
+    ("", "#"),
+    (None, "#"),
+])
+def test_subtopic(raw, formatted):
+    """assert that SubTopic.__str__ correctly reformats SubTopic._keys"""
+    assert str(SubTopic(raw)) == formatted


### PR DESCRIPTION
This was supposed to just add some tests for `SubTopic.__str__` and `PubTopic.__str__`, but the behavior wasn't what I expected so I ended up updating the source code too. I don't really understand the idea of sorting the tags in our routing keys, so please let me know if my guesses about what the output should be are wrong, and I can go back and fix.