### PR TITLE
fix(amqp): replace '.' topic separator in err queue binding w/ '_'

### DIFF
--- a/src/amqp_invoker.py
+++ b/src/amqp_invoker.py
@@ -96,9 +96,10 @@ class AmqpInvoker(Invoker):
                         await self.publish(channel_pool, message, routing_key=routing_key)
 
                 except Exception as err:  # pylint: disable=broad-except
-                    data_in['error'] = str(err)
                     # TODO(ahuman-bean): cleaner error messages
-                    message = aio_pika.Message(body=json.dumps(data_in).encode())
+                    data_in['error'] = str(err)
+                    # NOTE(ahuman-bean): have to nest metadata so error consumers can actually have access to them
+                    message = aio_pika.Message(body=json.dumps({"data": data_in}).encode())
                     routing_key = f'{self.queue_name.replace(".", "_")}_error'
                     await self.publish(channel_pool, message, routing_key)
 

--- a/src/amqp_invoker.py
+++ b/src/amqp_invoker.py
@@ -99,7 +99,7 @@ class AmqpInvoker(Invoker):
                     data_in['error'] = str(err)
                     # TODO(ahuman-bean): cleaner error messages
                     message = aio_pika.Message(body=json.dumps(data_in).encode())
-                    routing_key = f'{self.queue_name}_error'
+                    routing_key = f'{self.queue_name.replace(".", "_")}_error'
                     await self.publish(channel_pool, message, routing_key)
 
         return connection

--- a/src/amqp_invoker.py
+++ b/src/amqp_invoker.py
@@ -124,7 +124,7 @@ class AmqpInvoker(Invoker):
             queue_error = await channel.declare_queue(name=f'{self.queue_name}_error')
 
             await queue.bind(exchange=exchange, routing_key=str(self._invocable.config.subtopic))
-            await queue_error.bind(exchange=exchange, routing_key=f'{self.queue_name}_error')
+            await queue_error.bind(exchange=exchange, routing_key=f'{self.queue_name.replace(".", "_")}_error')
 
             async for message in queue:
                 async with message.process():


### PR DESCRIPTION
## Description

**Changes**


#### `.` is used as a topic separator: https://github.com/nautiluslabsco/ergo/blob/master/src/topic.py#L18

So currently, it is impossible to bind to any error queue containing `.` in its name.


#### Wrap/nest error payload/metadata in another `"data"` key to expose to downstream consumers

https://github.com/nautiluslabsco/ergo/pull/43/files#diff-408af79b4dbd03ba8e104983e4c47cca06fe51d3a90da05e79d865a0f22218a3R101-R102

## Example

Given a queue binding: `product.py:compute`, a corresponding `product.py:compute_error` queue / routing_key is also generated.
Attempting to bind a new queue to routing key `product.py:compute_error` would instead result in a binding of `#.py:compute_error.#.product.#`

## Notes

This would be a breaking change.
