### PR TITLE
separate traceback from exception

### DIFF
--- a/src/amqp_invoker.py
+++ b/src/amqp_invoker.py
@@ -26,7 +26,7 @@ def set_param(host: str, param_key: str, param_val: str) -> str:
     return uri._replace(query='&'.join(params)).geturl()
 
 
-def make_error_output(err: Exception) -> Dict:
+def make_error_output(err: Exception) -> Dict[str, str]:
     """Make a more digestable error output."""
     orig = err.__context__
     err_output = {

--- a/src/ergo_cli.py
+++ b/src/ergo_cli.py
@@ -129,7 +129,7 @@ class ErgoCli:
             int: Description
 
         """
-        config = Config({"func": func})
+        config = Config({'func': func})
         return self._http(config)
 
     def _http(self, config: Config):
@@ -172,12 +172,11 @@ class ErgoCli:
                 conf.update(namespace_cfg)
                 config = Config(conf)
 
-                if config.protocol == "amqp":
+                if config.protocol == 'amqp':
                     return self.amqp(config)
-                elif config.protocol == "http":
+                if config.protocol == 'http':
                     return self._http(config)
-                else:
-                    raise ValueError(f"unexpected protocol: {config.protocol}")
+                raise ValueError(f'unexpected protocol: {config.protocol}')
 
     def graph(self, *args: str) -> int:
         """Summary.

--- a/src/ergo_click.py
+++ b/src/ergo_click.py
@@ -5,6 +5,7 @@ Attributes:
 
 """
 from typing import Tuple
+
 import click
 from click_default_group import \
     DefaultGroup  # https://pypi.org/project/click-default-group/
@@ -129,6 +130,7 @@ def start(ref: str, arg: Tuple[str]) -> int:
 
     """
     return ERGO_CLI.start(ref, *list(arg))
+
 
 @main.command()
 @click.argument('ref', type=click.STRING)

--- a/src/flask_http_invoker.py
+++ b/src/flask_http_invoker.py
@@ -21,7 +21,7 @@ class FlaskHttpInvoker(HttpInvoker):
         """
         app: Flask = Flask(__name__)
 
-        @app.route(self.route, methods=["GET", "POST"])
+        @app.route(self.route, methods=['GET', 'POST'])
         def handler() -> str:  # type: ignore
             """Summary.
 

--- a/src/flask_http_invoker.py
+++ b/src/flask_http_invoker.py
@@ -1,7 +1,8 @@
 """Summary."""
-from typing import List
 import inspect
 import json
+from typing import List
+
 from flask import Flask, request  # , abort
 
 from src.http_invoker import HttpInvoker

--- a/src/function_invocable.py
+++ b/src/function_invocable.py
@@ -11,7 +11,7 @@ from typing import Callable, Generator, Match, Optional
 
 from src.config import Config
 from src.types import TYPE_PAYLOAD, TYPE_RETURN
-from src.util import log, print_exc_plus
+from src.util import print_exc_plus
 
 
 class FunctionInvocable:

--- a/src/util.py
+++ b/src/util.py
@@ -1,9 +1,10 @@
 """Convenience Funcs for handling errors, logging, and monitoring."""
+import re
 import sys
 import time
 import traceback
 from types import FrameType, TracebackType
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from uuid import uuid4
 
 if sys.version_info >= (3, 8):
@@ -104,3 +105,22 @@ def print_exc_plus() -> str:  # pragma: no cover
                 ret = f'{ret}\n<ERROR WHILE PRINTING VALUE>'
 
     return ret
+
+
+def extract_from_stack(exc: BaseException) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """
+    Extract minimal useful information from top of function stack.
+
+    Returns:
+        str: filename
+        str: lineno
+        str: function name
+    """
+    traceback_exception = traceback.TracebackException.from_exception(exc)
+    stack_string = traceback_exception.stack.format()[-1]
+    # File ".*", line n+, in s+\n
+    prog = re.compile(r'File ".+/(\w+[.]py)", line (\d+), in (\w+)\n')
+    match = prog.search(stack_string)
+    if match:
+        return match.groups()
+    return None, None, None

--- a/src/util.py
+++ b/src/util.py
@@ -122,5 +122,7 @@ def extract_from_stack(exc: BaseException) -> Tuple[Optional[str], Optional[str]
     prog = re.compile(r'File ".+/(\w+[.]py)", line (\d+), in (\w+)\n')
     match = prog.search(stack_string)
     if match:
-        return match.groups()
+        matches = match.groups()
+        if len(matches) == 3:  # for mypy
+            return matches[0], matches[1], matches[2]
     return None, None, None

--- a/src/version.py
+++ b/src/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.5.5-alpha'
+VERSION = '0.5.6-alpha'
 
 
 def get_version() -> str:

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -33,3 +33,24 @@ class TestUtil(unittest.TestCase):
         frames = f1()
         for code, frame in zip(['f3', 'f2', 'f1'], frames):
             assert code in str(frame.f_code), f'code is: {code}, frame is: {frame}'
+
+    def test_extract(self):
+        def f3():
+            raise IndexError('zeke')
+
+        def f2():
+            try:
+                f3()
+            except IndexError as inner_e:
+                raise ValueError('reyna') from inner_e
+
+        def f1():
+            try:
+                f2()
+            except Exception as e:
+                return util.extract_from_stack(e)
+
+        filename, lineno, function_name = f1()
+        assert filename == 'test_util.py'
+        assert lineno == '45'
+        assert function_name == 'f2'


### PR DESCRIPTION
## Description

Issue: https://github.com/nautiluslabsco/ergo/issues/23

Separating `error` from `traceback` so that we can at a glance debug several messages in the rabbitmq console. This leverages exception chaining: https://docs.python.org/3/tutorial/errors.html#exception-chaining to grab the originating exception and the traceback information from the same object.

## Visuals

function code that leads to index error:
![Screen Shot 2021-11-24 at 11 05 35 AM](https://user-images.githubusercontent.com/58951029/143292914-dad8d29b-87e8-44b9-a30f-c142402d9bd8.png)

input message:
![Screen Shot 2021-11-24 at 11 04 16 AM](https://user-images.githubusercontent.com/58951029/143292910-51120b72-074c-4350-8a1a-ddcd00ba8fd4.png)

error message:
![Screen Shot 2021-11-24 at 11 05 17 AM](https://user-images.githubusercontent.com/58951029/143292913-532be79e-7936-456b-a244-d9321a44c2f8.png)

note that `error` now says the more human readable:
`TypeError: 'int' object is not subscriptable`

## Thoughts
There are some annoying linting errors that are popping up... think it would be nice if linting wasn't kicked off pre-commit but rather as a blocker to merging. Maybe linting should automatically clean up the code rather than whine about it as well?