### PR TITLE
remove .py from routing key and queue name

### DIFF
--- a/src/amqp_invoker.py
+++ b/src/amqp_invoker.py
@@ -50,7 +50,7 @@ class AmqpInvoker(Invoker):
 
         self.url = set_param(host, 'heartbeat', str(heartbeat)) if heartbeat else host
         self.exchange_name = self._invocable.config.exchange
-        self.queue_name = self._invocable.config.func
+        self.queue_name = self._invocable.config.func.replace('.py', '')
 
     def start(self) -> int:
         """


### PR DESCRIPTION
## Description

https://github.com/nautiluslabsco/ergo/issues/45

Update amqp invoker, s.t. `.py` isn't part of queue name, or routing keys.

## Visuals