### PR TITLE
chore: bump to `0.6.0-alpha`

### DIFF
--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.5.8-alpha'
+VERSION = '0.6.0-alpha'
 
 
 def get_version() -> str:


### PR DESCRIPTION
https://github.com/nautiluslabsco/ergo/commit/81a31515c3c397fc430e5e1a235e35ca28581d65 was a breaking change from `0.5.7-alpha`, but some python dependency managers may allow the upgrade from `0.5.7a` to `0.5.8a` as an innocuous change.