### PR TITLE
add Payload constructors and refactor internal data structure

### DIFF
--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -135,7 +135,8 @@ class AmqpInvoker(Invoker):
 
             async for message in queue:
                 async with message.process():
-                    yield Payload.from_string(message.body.decode('utf-8'))
+                    payload = Payload.from_string(message.body.decode('utf-8'))
+                    yield payload
 
     async def publish(self, channel_pool: aio_pika.pool.Pool[aio_pika.RobustChannel], message: aio_pika.Message, routing_key: str) -> None:
         """

--- a/ergo/flask_http_invoker.py
+++ b/ergo/flask_http_invoker.py
@@ -30,7 +30,7 @@ class FlaskHttpInvoker(HttpInvoker):
                 str: Description
 
             """
-            data_in: TYPE_PAYLOAD = Payload(request.args)
+            data_in: TYPE_PAYLOAD = Payload.from_dict(dict(request.args))
             data_out: List[TYPE_PAYLOAD] = list(self._invocable.invoke(data_in))
             if not inspect.isgeneratorfunction(self._invocable.func):
                 data_out = data_out[0]

--- a/ergo/function_invocable.py
+++ b/ergo/function_invocable.py
@@ -78,7 +78,7 @@ class FunctionInvocable:
         try:
             args = []
             for arg in self.config.args:
-                args.append(data_in.get(arg, data_in.get(f"data.{arg}")))
+                args.append(data_in.get(f"data.{arg}", data_in.get(arg)))
             result = self._func(*args)
             if inspect.isgenerator(result):
                 yield from result

--- a/ergo/function_invocable.py
+++ b/ergo/function_invocable.py
@@ -76,7 +76,9 @@ class FunctionInvocable:
         if not self._func:
             raise Exception('Cannot execute injected function')
         try:
-            args = [data_in.get(self.config.args[arg]) for arg in self.config.args]
+            args = []
+            for arg in self.config.args:
+                args.append(data_in.get(arg, data_in.get(f"data.{arg}")))
             result = self._func(*args)
             if inspect.isgenerator(result):
                 yield from result

--- a/ergo/payload.py
+++ b/ergo/payload.py
@@ -1,6 +1,6 @@
 """Summary."""
 import json
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import pydash
 
@@ -8,16 +8,31 @@ import pydash
 class Payload:
     """Summary."""
 
-    def __init__(self, data: Optional[Dict[str, str]] = None) -> None:
+    def __init__(self, key: Optional[str], log: List, data: Any) -> None:
         """Summary.
 
         Args:
             data (Optional[Dict[str, str]], optional): Description
 
         """
-        self._data: Dict[str, str] = data or {}
+        self._data: Dict = {"key": key, "log": log, "data": data}
 
-    def get(self, key: str, default=None) -> Optional[str]:
+    @classmethod
+    def from_string(cls, data: str):
+        return cls.from_dict(json.loads(data))
+
+    @classmethod
+    def from_dict(cls, data: Dict):
+        key = data.get("key")
+        log = data.pop("log", [])
+        payload = cls(key=key, log=log, data=data)
+        return payload
+
+    @property
+    def log(self) -> List:
+        return self._data["log"]
+
+    def get(self, key: str, default=None):
         """Summary.
 
         Args:
@@ -39,12 +54,11 @@ class Payload:
         """
         self._data[key] = value
 
-    def unset(self, key: str) -> str:
+    def unset(self, key: str):
         """Summary.
 
         Args:
             key (str): Description
-            value (str): Description
 
         """
         return self._data.pop(key, None)

--- a/ergo/payload.py
+++ b/ergo/payload.py
@@ -23,7 +23,7 @@ class Payload:
 
     @classmethod
     def from_dict(cls, data: Dict):
-        key = data.get("key")
+        key = data.pop("key", None)
         log = data.pop("log", [])
         payload = cls(key=key, log=log, data=data)
         return payload


### PR DESCRIPTION
This repurposes the Payload constructor for creating new outbound Payload objects from function return values, and adds `from_string` and `from_dict` factory methods for creating them from inbound messages. It also restructures `Payload._data` to nest function return values under a `data` key, separate from metadata like context and log. Because of the way `Payload.get` uses `pydash.get` to read from this dictionary, this preserves the special status of "data" as a function parameter, while also making it optional. If some component invokes a function that returns `{"x" x, "y": y}`, then these subscriber implementations would both work interchangeably:

```
def foo(context, x, y):
  return x * y

def bar(context, data):
  return data['x'] * data['y']
```

Supporting both styles is arguably hacky, but it also gives ergo a way to support upstream components returning values that aren't nested in dicts (and thus aren't associated with keywords), because downstream functions can continue binding them to a "data" parameter. See the [new test](https://github.com/nautiluslabsco/ergo/pull/56/files#diff-f4dcd9e2a40d5b8a8b65bf65ec710f587646331e992f4df7b70134c8d91cfe43R41-R75) for an example.

These changes are blocking my implementation for https://nautiluslabs.atlassian.net/browse/PD-613, but now I can't remember why. I'll update this description when I do `¯\_(ツ)_/¯`.