### PR TITLE
Schubert/instance subscriptions pd 611 pd 612

### DIFF
--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -95,7 +95,7 @@ class AmqpInvoker(Invoker):
             async for data_in in self.consume(channel_pool):
                 try:
                     async for data_out in self.do_work(data_in):
-                        if data_in.stack and data_in.stack.get_callback_key():
+                        if data_in.stack and data_in.stack.get_reply_to():
                             data_out.key = f"{data_out.key}.response"
                         message = aio_pika.Message(body=encodes(data_out).encode('utf-8'))
                         routing_key = str(PubTopic(data_out.key))

--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -95,8 +95,9 @@ class AmqpInvoker(Invoker):
             async for data_in in self.consume(channel_pool):
                 try:
                     async for data_out in self.do_work(data_in):
-                        if data_in.stack and data_in.stack.get_reply_to():
-                            data_out.key = f"{data_out.key}.response"
+                        # if data_in.stack and data_in.stack.get_reply_to():
+                        if data_in.key and '.request' in data_in.key:
+                            data_out.key = f"{data_in.stack.get_reply_to()}.{data_out.key}.response"
                         message = aio_pika.Message(body=encodes(data_out).encode('utf-8'))
                         routing_key = str(PubTopic(data_out.key))
                         await self.publish(channel_pool, message, routing_key=routing_key)

--- a/ergo/context.py
+++ b/ergo/context.py
@@ -16,12 +16,38 @@ class Context:
         self._results_stream = results_stream
 
     def request(self, topic: str, **kwargs):
+        """
+        Publish a message with the given topic and data. Receiving components may call `Context.respond` to
+        reply directly to the sending instance.
+
+        >>> import random
+        >>> x = random.random()
+        >>> def requester(context: Context, r=None):
+        ...     global x
+        ...     if r:
+        ...         assert r == x
+        ...     else:
+        ...         context.request('responder', r=x)
+        ...
+        >>> def responder(context: Context, r):
+        ...     context.respond(r=r)
+        ...
+
+        """
         with self._transaction():
             self._stack.set_reply_to(instance_id())
             self._results_stream.send(Payload(data=kwargs or None, key=f"{topic}.request", stack=self._stack))
 
     def respond(self, data=None, **kwargs):
+        """
+        See docstring for Context.request.
+
+        """
         if self._stack.get_reply_to() == instance_id():
+            # We must be inside a recursive request stack, and the current transaction is associated with a request call
+            # that we made in a prior invocation. If its parent is null, then we've reached the 'base case' and should
+            # terminate recursion by publishing to our current pubtopic. Otherwise, the parent transaction is associated
+            # with the request that we're responding to now.
             self._close_transaction()
         if self._stack:
             key = self._stack.get_reply_to()

--- a/ergo/context.py
+++ b/ergo/context.py
@@ -17,14 +17,14 @@ class Context:
 
     def request(self, topic: str, **kwargs):
         with self._transaction():
-            self._stack.set_callback_key(instance_id())
+            self._stack.set_reply_to(instance_id())
             self._results_stream.send(Payload(data=kwargs or None, key=f"{topic}.request", stack=self._stack))
 
     def respond(self, data=None, **kwargs):
-        if self._stack.get_callback_key() == instance_id():
+        if self._stack.get_reply_to() == instance_id():
             self._close_transaction()
         if self._stack:
-            key = self._stack.get_callback_key()
+            key = self._stack.get_reply_to()
         else:
             key = self.pubtopic
         self._results_stream.send(Payload(data=data or kwargs, key=key, stack=self._stack))

--- a/ergo/context.py
+++ b/ergo/context.py
@@ -49,10 +49,9 @@ class Context:
             # terminate recursion by publishing to our current pubtopic. Otherwise, the parent transaction is associated
             # with the request that we're responding to now.
             self._close_transaction()
-        if self._stack:
-            key = self._stack.get_reply_to()
-        else:
-            key = self.pubtopic
+        key = self.pubtopic
+        # if self._stack:
+        #     key = f"{key}.{self._stack.get_reply_to()}"
         self._results_stream.send(Payload(data=data or kwargs, key=key, stack=self._stack))
 
     @contextmanager

--- a/ergo/context.py
+++ b/ergo/context.py
@@ -1,12 +1,41 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
 from typing import Optional
 
+from ergo.payload import Payload
+from ergo.results_stream import ResultsStream
 from ergo.stack import Stack
+from ergo.util import instance_id
 
 
 class Context:
-    def __init__(self, pubtopic: str, stack: Optional[Stack]):
+    def __init__(self, pubtopic: str, stack: Optional[Stack], results_stream: ResultsStream):
         self.pubtopic = pubtopic
         self._stack = stack
+        self._results_stream = results_stream
+
+    def request(self, topic: str, **kwargs):
+        with self._transaction():
+            self._stack.set_callback_key(instance_id())
+            self._results_stream.send(Payload(data=kwargs or None, key=f"{topic}.request", stack=self._stack))
+
+    def respond(self, data=None, **kwargs):
+        if self._stack.get_callback_key() == instance_id():
+            self._close_transaction()
+        if self._stack:
+            key = self._stack.get_callback_key()
+        else:
+            key = self.pubtopic
+        self._results_stream.send(Payload(data=data or kwargs, key=key, stack=self._stack))
+
+    @contextmanager
+    def _transaction(self):
+        self._open_transaction()
+        try:
+            yield
+        finally:
+            self._close_transaction()
 
     def _open_transaction(self):
         if self._stack:

--- a/ergo/invoker.py
+++ b/ergo/invoker.py
@@ -2,9 +2,9 @@
 from abc import ABC, abstractmethod
 from typing import Generator
 
-from ergo.context import Context
 from ergo.function_invocable import FunctionInvocable
 from ergo.payload import Payload
+from ergo.util import instance_id
 
 
 class Invoker(ABC):
@@ -18,6 +18,7 @@ class Invoker(ABC):
 
         """
         super().__init__()
+        self.instance_id = instance_id()
         self._invocable = invocable
 
     @abstractmethod

--- a/ergo/results_stream.py
+++ b/ergo/results_stream.py
@@ -1,0 +1,21 @@
+from collections.abc import Generator
+from typing import List
+
+from ergo.payload import Payload
+
+
+class ResultsStream(Generator):
+    def __init__(self):
+        self.results: List[Payload] = []
+
+    def __next__(self) -> Payload:
+        try:
+            return self.results.pop(0)
+        except IndexError:
+            raise StopIteration
+
+    def send(self, payload: Payload):
+        self.results.append(payload)
+
+    def throw(self, *args, **kwargs):
+        raise StopIteration

--- a/ergo/stack.py
+++ b/ergo/stack.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Dict, Optional
 
 from ergo.util import uniqueid
 
@@ -9,6 +9,7 @@ from ergo.util import uniqueid
 @dataclass
 class Stack:
     id: str = field(default_factory=uniqueid)
+    data: Dict = field(default_factory=dict)
     parent: Optional[Stack] = None
 
     def push(self: Stack) -> Stack:
@@ -16,3 +17,9 @@ class Stack:
 
     def pop(self) -> Optional[Stack]:
         return self.parent
+
+    def get_callback_key(self) -> Optional[str]:
+        return self.data.get("callback_key")
+
+    def set_callback_key(self, value: str):
+        self.data["callback_key"] = value

--- a/ergo/stack.py
+++ b/ergo/stack.py
@@ -18,8 +18,8 @@ class Stack:
     def pop(self) -> Optional[Stack]:
         return self.parent
 
-    def get_callback_key(self) -> Optional[str]:
-        return self.data.get("callback_key")
+    def get_reply_to(self) -> Optional[str]:
+        return self.data.get('reply_to')
 
-    def set_callback_key(self, value: str):
-        self.data["callback_key"] = value
+    def set_reply_to(self, value: str):
+        self.data['reply_to'] = value

--- a/ergo/util.py
+++ b/ergo/util.py
@@ -3,6 +3,7 @@ import re
 import sys
 import time
 import traceback
+from functools import lru_cache
 from types import FrameType, TracebackType
 from typing import List, Optional, Tuple
 from uuid import uuid4
@@ -126,3 +127,8 @@ def extract_from_stack(exc: BaseException) -> Tuple[Optional[str], Optional[str]
         if len(matches) == 3:  # for mypy
             return matches[0], matches[1], matches[2]
     return None, None, None
+
+
+@lru_cache(1)
+def instance_id() -> str:
+    return uniqueid()

--- a/test/integration/amqp/test_request.py
+++ b/test/integration/amqp/test_request.py
@@ -18,10 +18,13 @@ def pong(context: Context, data):
         context.respond(response='pong')
 
 
-@amqp_component(ping)
-@amqp_component(pong, subtopic='pong')
+@amqp_component(ping, subtopic="ping_sub", pubtopic="ping_pub")
+@amqp_component(pong, subtopic='pong', pubtopic="pong_pub")
 def test_ping_pong(components):
     ping_component = components[0]
+    ping_component.send()
+    while True:
+        bh = True
     result = ping_component.rpc()['data']
     assert result == {'ping': 'pong'}
 
@@ -70,6 +73,8 @@ node_d = Node('d')
 def test_traverse_tree(components):
     root_node = components[0]
     root_node.send()
+    while True:
+        bh = True
     results = [root_node.consume()['data']['path'] for _ in range(2)]
     results = sorted(results)
     assert results == ['a.b.c', 'a.b.d']

--- a/test/integration/amqp/test_request.py
+++ b/test/integration/amqp/test_request.py
@@ -1,0 +1,75 @@
+from typing import Optional, List
+from ergo.context import Context
+from test.integration.amqp.utils import amqp_component
+
+"""
+test_ping_pong
+"""
+
+
+def ping(context: Context, response=None):
+    if response:
+        return {'ping': response}
+    context.request('pong', ping=True)
+
+
+def pong(context: Context, data):
+    if data.get('ping'):
+        context.respond(response='pong')
+
+
+@amqp_component(ping)
+@amqp_component(pong, subtopic='pong')
+def test_ping_pong(components):
+    ping_component = components[0]
+    result = ping_component.rpc()['data']
+    assert result == {'ping': 'pong'}
+
+
+"""
+test_traverse_tree
+
+Each node in the tree below is implemented with a component. The test sends a message to node A,
+which recursively requests a path from each of its children, and then responds with that path, prepended with its 
+own ID. Node A should ultimately publish two strings, 'a.b.c' and 'a.b.d'.
+
+    a
+    |
+    b
+  /   \
+c       d
+
+"""
+
+
+class Node:
+    def __init__(self, name: str, children: Optional[List[str]] = None):
+        self.id = name
+        self.children: List[str] = children or []
+
+    def __call__(self, context: Context, path=None):
+        if path:
+            context.respond(path=f'{self.id}.{path}')
+        elif self.children:
+            for child in self.children:
+                context.request(f'traverse.{child}')
+        else:
+            context.respond(path=self.id)
+
+
+node_a = Node('a', children=['b'])
+node_b = Node('b', children=['c', 'd'])
+node_c = Node('c')
+node_d = Node('d')
+
+
+@amqp_component(node_a, subtopic='a')
+@amqp_component(node_b, subtopic='b')
+@amqp_component(node_c, subtopic='c')
+@amqp_component(node_d, subtopic='d')
+def test_traverse_tree(components):
+    root_node = components[0]
+    root_node.send()
+    results = [root_node.consume()['data']['path'] for _ in range(2)]
+    results = sorted(results)
+    assert results == ['a.b.c', 'a.b.d']

--- a/test/integration/amqp/test_stack.py
+++ b/test/integration/amqp/test_stack.py
@@ -43,9 +43,9 @@ test_nested_transaction
 
 def nested_transaction(context):
     context._open_transaction()
-    yield
+    yield True
     context._open_transaction()
-    yield
+    yield True
 
 
 @amqp_component(nested_transaction)
@@ -65,9 +65,9 @@ test_closing_transaction
 
 def closing_transaction(context):
     context._open_transaction()
-    yield
+    yield True
     context._close_transaction()
-    yield
+    yield True
 
 
 @amqp_component(closing_transaction)

--- a/test/integration/amqp/utils.py
+++ b/test/integration/amqp/utils.py
@@ -40,12 +40,7 @@ class AMQPComponent(Component):
         handler_module = pathlib.Path(self.handler_path).with_suffix("").name
         self.subtopic = subtopic or f"{handler_module}_{self.handler_name}_sub"
         self.pubtopic = pubtopic or f"{handler_module}_{self.handler_name}_pub"
-        self.channel = new_channel()
-        self._subscription_queue = self.channel.queue_declare(
-            queue="",
-            exclusive=True,
-        ).method.queue
-        self.channel.queue_bind(self._subscription_queue, EXCHANGE, routing_key=str(SubTopic(self.pubtopic)))
+
 
     @property
     def namespace(self):
@@ -120,6 +115,14 @@ class AMQPComponent(Component):
         if not _LIVE_COMPONENTS[self.func]:
             self.await_startup()
         _LIVE_COMPONENTS[self.func] += 1
+
+        self.channel = new_channel()
+        self._subscription_queue = self.channel.queue_declare(
+            queue="",
+            exclusive=True,
+        ).method.queue
+        self.channel.queue_bind(self._subscription_queue, EXCHANGE, routing_key=str(SubTopic(self.pubtopic)))
+
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/test/integration/test_http.py
+++ b/test/integration/test_http.py
@@ -62,10 +62,6 @@ def get_two_dicts():
     return [get_dict(), get_dict()]
 
 
-def get_none():
-    return None
-
-
 def yield_one_dict():
     yield get_dict()
 
@@ -79,7 +75,6 @@ def yield_two_dicts():
     get_dict,
     get_one_dict,
     get_two_dicts,
-    get_none,
     yield_one_dict,
     yield_two_dicts,
 ])


### PR DESCRIPTION
1. Assign component instances unique IDs provided by `utils.uniqueid`.
2. Bind the AMQPInvoker's main consumer queue to that instance ID.
3. Add a `Stack.data` attribute to store unstructured (at least for now) key-value data.
4. Use the above to implement `Context.request` and `Context.respond`. `request` takes a topic and optional data, and generates an outbound payload to be published with that topic in a temporary transaction. `respond` takes arbitrary data, and generates an outbound payload to be published with the requester's instance ID as the routing key. The responder's normal pubtopic isn't included in that routing key, nor is the transaction ID associated with request. This way, the responder doesn't have to be responsible for knowing which other components might have received the same request, or what side effects might follow if they received each other's responses.