### PR TITLE
declare and consume amqp queues with dedicated channels

### DIFF
--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.7.1-alpha'
+VERSION = '0.7.2-alpha'
 
 
 def get_version() -> str:


### PR DESCRIPTION
This is a hail mary attempt to solve that DuplicateConsumerTag error that's been showing up in the [telenor connector](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fecs$252Fqed-telenor_api_connector-qa/log-events/ecs$252Fqed-telenor_api_connector-qa$252F44de56c219ef498ca557a1eb9e9cffe5). Digging through the [code](https://github.com/mosquito/aiormq/blob/master/aiormq/channel.py#L478), I haven't figured out specifically how we could be triggering that exception. But I did notice that we're declaring both queues with the same channel, and that we'll end up using that channel in both consumer loops. Channels aren't supposed to be shared btw threads, so even though I can't figure out how it could be responsible for this bug, I still think we need to change it.