### PR TITLE
correctly apply configuration args mappings

### DIFF
--- a/ergo/config.py
+++ b/ergo/config.py
@@ -26,22 +26,22 @@ class Config:
         self._exchange: Optional[str] = config.get('exchange')
         self._protocol: str = config.get('protocol', 'stack')  # http, amqp, stdio, stack
         self._heartbeat: Optional[str] = config.get('heartbeat')
-        self._args: Optional[OrderedDict] = None
+        self._args: Optional[dict] = config.get('args')
 
     def copy(self):
         return copy.deepcopy(self)
 
     @property
-    def args(self):
+    def args(self) -> dict:
         """Summary.
 
         Returns:
             TYPE: Description
         """
-        return self._args
+        return self._args or {}
 
     @args.setter
-    def args(self, val: OrderedDict) -> None:
+    def args(self, val: dict) -> None:
         """Summary.
 
         Returns:

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.7.1-alpha'
+VERSION = '0.7.2-alpha'
 
 
 def get_version() -> str:

--- a/test/integration/amqp/test_amqp.py
+++ b/test/integration/amqp/test_amqp.py
@@ -134,3 +134,20 @@ def test_make_six(components):
         make_six_component.propagate_error(inactivity_timeout=0.1)
         forward_component.propagate_error(inactivity_timeout=0.1)
     assert result["data"] == 6
+
+
+"""
+test_config_args
+
+This test asserts that ergo can correctly bind message data to a custom parameter using the `args` configuration attribute.
+"""
+
+
+def config_args_test_component(my_data_param):
+    return my_data_param
+
+
+@amqp_component(config_args_test_component, args={"my_data_param": "data"})
+def test_config_args(component):
+    result = component.rpc(data="some data")
+    assert result["data"] == "some data"

--- a/test/integration/utils/__init__.py
+++ b/test/integration/utils/__init__.py
@@ -75,7 +75,7 @@ class Component(ContextDecorator, ABC):
 
 
 class FunctionComponent(Component, ABC):
-    def __init__(self, func: Callable):
+    def __init__(self, func: Callable, **manifest_kwargs):
         super().__init__()
         self.func = func
         if inspect.isfunction(func):
@@ -88,11 +88,13 @@ class FunctionComponent(Component, ABC):
             string = inspect.getframeinfo(frame[0]).code_context[0].strip()
             self.handler_path = inspect.getfile(func.__call__)
             self.handler_name = re.search(r"\((.*?)[,)]", string).group(1)
+        self._manifest_kwargs = manifest_kwargs
 
     @property
     def manifest(self):
         return {
-            "func": f"{self.handler_path}:{self.handler_name}"
+            "func": f"{self.handler_path}:{self.handler_name}",
+            **self._manifest_kwargs,
         }
 
     @property

--- a/test/integration/utils/amqp.py
+++ b/test/integration/utils/amqp.py
@@ -39,8 +39,9 @@ class AMQPComponent(FunctionComponent):
         func: Callable,
         subtopic: Optional[str] = None,
         pubtopic: Optional[str] = None,
+        **manifest
     ):
-        super().__init__(func)
+        super().__init__(func, **manifest)
         self.queue_name = f"{self.handler_path.replace('/', ':')[1:]}:{self.handler_name}"
         self.error_queue_name = f"{self.queue_name}:error"
         handler_module = pathlib.Path(self.handler_path).with_suffix("").name


### PR DESCRIPTION
I just noticed that ergo 0.6.0a dropped support for custom `args` mapping in configuration yamls. This PR fixes that, and adds an integration test to cover it.