### PR TITLE
pin jinja2 to fix quart import error

### DIFF
--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.8.3-alpha'
+VERSION = '0.8.4-alpha'
 
 
 def get_version() -> str:

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(
         'jsons',
         'quart',
         'kombu',
+        'jinja2>=3.0,<3.1',  # 3.1.0 removes jinja2.escape, which Quart implicitly requires as of 2022/03/25
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',  # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package


### PR DESCRIPTION
Quart doesn't pin its jinja2 [requirement](https://github.com/pgjones/quart/blob/main/pyproject.toml#L35), but it raises an ImportError with the latest minor version. So for now, we'll have to pin jinja2 ourselves.

![image](https://user-images.githubusercontent.com/88679481/160157668-2470c082-0e0e-48e9-930f-7b8b9eb34035.png)
