### PR TITLE
chore(context): safer retrieve

### DIFF
--- a/ergo/context.py
+++ b/ergo/context.py
@@ -40,9 +40,9 @@ class Context:
     def exit_scope(self):
         self._scope = self._scope.parent
 
-    def retrieve(self, key: str) -> Any:
+    def retrieve(self, key: str) -> Optional[Any]:
         if self._scope:
-            return self._scope.data[key]
+            return self._scope.data.get(key)
 
     def store(self, key: str, value: Any):
         if self._scope:

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.8.6-alpha'
+VERSION = '0.8.7-alpha'
 
 
 def get_version() -> str:


### PR DESCRIPTION
Since retrieve doesn't imply index semantics, we should opt for returning `Optional` types so that the caller isn't required to wrap every invocation with a try/except.