### PR TITLE
[Inf 250] feat(queue clean up): unbind component at shutdown

### DIFF
--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -144,7 +144,9 @@ class AmqpInvoker(Invoker):
     def _shutdown(self, signum, *_):
         self._terminating.set()
         self._pending_invocations.acquire(blocking=True, timeout=TERMINATION_GRACE_PERIOD)
-        self._component_queue.queue_unbind()
+        consumer_count = self._component_queue.queue_declare()[2]
+        if consumer_count <= 1:
+            self._component_queue.queue_unbind()
         self._connection.close()
         signal.signal(signum, 0)
         signal.raise_signal(signum)

--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -19,8 +19,6 @@ from ergo.message import Message, decodes, encodes
 from ergo.topic import PubTopic, SubTopic
 from ergo.util import extract_from_stack, instance_id
 
-import sys
-
 logger = logging.getLogger(__name__)
 
 PREFETCH_COUNT = 1
@@ -63,6 +61,8 @@ class AmqpInvoker(Invoker):
         if component_queue_name.startswith(":"):
             component_queue_name = component_queue_name[1:]
         self._component_queue = kombu.Queue(name=component_queue_name, exchange=self._exchange, routing_key=str(SubTopic(self._invocable.config.subtopic)), durable=False, channel=self._connection.channel())
+        print('bindings', dir(self._component_queue))
+        print('bindings', self._component_queue.as_dict)
         instance_queue_name = f"{component_queue_name}:{instance_id()}"
         self._instance_queue = kombu.Queue(name=instance_queue_name, exchange=self._exchange, routing_key=str(SubTopic(instance_id())), auto_delete=True)
         error_queue_name = f"{component_queue_name}:error"

--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -20,6 +20,7 @@ from ergo.topic import PubTopic, SubTopic
 from ergo.util import extract_from_stack, instance_id
 
 import sys
+
 logger = logging.getLogger(__name__)
 
 PREFETCH_COUNT = 1

--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -61,9 +61,7 @@ class AmqpInvoker(Invoker):
         super().__init__(invocable)
 
         heartbeat = self._invocable.config.heartbeat or DEFAULT_HEARTBEAT
-        self._connection = kombu.Connection(
-            self._invocable.config.host, heartbeat=heartbeat
-        )
+        self._connection = kombu.Connection(self._invocable.config.host, heartbeat=heartbeat)
         self._exchange = kombu.Exchange(
             name=self._invocable.config.exchange,
             type="topic",
@@ -175,9 +173,7 @@ class AmqpInvoker(Invoker):
 
     def _shutdown(self, signum, *_):
         self._terminating.set()
-        self._pending_invocations.acquire(
-            blocking=True, timeout=TERMINATION_GRACE_PERIOD
-        )
+        self._pending_invocations.acquire(blocking=True, timeout=TERMINATION_GRACE_PERIOD)
         self._component_queue.queue_unbind()
         self._connection.close()
         signal.signal(signum, 0)

--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -20,7 +20,6 @@ from ergo.topic import PubTopic, SubTopic
 from ergo.util import extract_from_stack, instance_id
 
 import sys
-
 logger = logging.getLogger(__name__)
 
 PREFETCH_COUNT = 1
@@ -31,26 +30,21 @@ DEFAULT_HEARTBEAT = 60  # seconds.
 
 def set_param(host: str, param_key: str, param_val: str) -> str:
     """Overwrite a param in a host string w a new value."""
-    uri, new_param = urlparse(host), f"{param_key}={param_val}"
-    params = [p for p in uri.query.split("&") if param_key not in p] + [new_param]
-    return uri._replace(query="&".join(params)).geturl()
+    uri, new_param = urlparse(host), f'{param_key}={param_val}'
+    params = [p for p in uri.query.split('&') if param_key not in p] + [new_param]
+    return uri._replace(query='&'.join(params)).geturl()
 
 
 def make_error_output(err: Exception) -> Dict[str, str]:
     """Make a more digestible error output."""
     orig = err.__context__ or err
     err_output = {
-        "type": type(orig).__name__,
-        "message": str(orig),
+        'type': type(orig).__name__,
+        'message': str(orig),
     }
     filename, lineno, function_name = extract_from_stack(orig)
     if None not in (filename, lineno, function_name):
-        err_output = {
-            **err_output,
-            "file": filename,
-            "line": lineno,
-            "func": function_name,
-        }
+        err_output = {**err_output, 'file': filename, 'line': lineno, 'func': function_name}
     return err_output
 
 
@@ -62,37 +56,16 @@ class AmqpInvoker(Invoker):
 
         heartbeat = self._invocable.config.heartbeat or DEFAULT_HEARTBEAT
         self._connection = kombu.Connection(self._invocable.config.host, heartbeat=heartbeat)
-        self._exchange = kombu.Exchange(
-            name=self._invocable.config.exchange,
-            type="topic",
-            durable=True,
-            auto_delete=False,
-        )
+        self._exchange = kombu.Exchange(name=self._invocable.config.exchange, type="topic", durable=True, auto_delete=False)
 
         component_queue_name = f"{self._invocable.config.func}".replace("/", ":")
         if component_queue_name.startswith(":"):
             component_queue_name = component_queue_name[1:]
-        self._component_queue = kombu.Queue(
-            name=component_queue_name,
-            exchange=self._exchange,
-            routing_key=str(SubTopic(self._invocable.config.subtopic)),
-            durable=False,
-            channel=self._connection.channel(),
-        )
+        self._component_queue = kombu.Queue(name=component_queue_name, exchange=self._exchange, routing_key=str(SubTopic(self._invocable.config.subtopic)), durable=False, channel=self._connection.channel())
         instance_queue_name = f"{component_queue_name}:{instance_id()}"
-        self._instance_queue = kombu.Queue(
-            name=instance_queue_name,
-            exchange=self._exchange,
-            routing_key=str(SubTopic(instance_id())),
-            auto_delete=True,
-        )
+        self._instance_queue = kombu.Queue(name=instance_queue_name, exchange=self._exchange, routing_key=str(SubTopic(instance_id())), auto_delete=True)
         error_queue_name = f"{component_queue_name}:error"
-        self._error_queue = kombu.Queue(
-            name=error_queue_name,
-            exchange=self._exchange,
-            routing_key=error_queue_name,
-            durable=False,
-        )
+        self._error_queue = kombu.Queue(name=error_queue_name, exchange=self._exchange, routing_key=error_queue_name, durable=False)
         self._terminating = threading.Event()
         self._pending_invocations = threading.Semaphore()
         self._handler_lock = threading.Lock()
@@ -102,11 +75,7 @@ class AmqpInvoker(Invoker):
         signal.signal(signal.SIGINT, self._shutdown)
         with self._connection:
             conn = self._connection
-            consumer: kombu.Consumer = conn.Consumer(
-                queues=[self._component_queue, self._instance_queue],
-                prefetch_count=PREFETCH_COUNT,
-                accept=["json"],
-            )
+            consumer: kombu.Consumer = conn.Consumer(queues=[self._component_queue, self._instance_queue], prefetch_count=PREFETCH_COUNT, accept=["json"])
             consumer.register_callback(self._start_handle_message_thread)
             consumer.consume()
 
@@ -151,7 +120,7 @@ class AmqpInvoker(Invoker):
             dt = datetime.datetime.now(datetime.timezone.utc)
             message_in.error = make_error_output(err)
             message_in.traceback = str(err)
-            message_in.scope.metadata["timestamp"] = dt.isoformat()
+            message_in.scope.metadata['timestamp'] = dt.isoformat()
             self._publish(message_in, self._error_queue.name)
 
     def _publish(self, ergo_message: Message, routing_key: str):

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.8.9-alpha'
+VERSION = '0.8.10-alpha'
 
 
 def get_version() -> str:


### PR DESCRIPTION
 - if component's subtopic gets changed, the old binding is left straggling
 - this change removes bindings from the component's queue at component shutdown -> when a new component instance is spun up it binds back to a 'clean' queue
[INF-250](https://nautiluslabs.atlassian.net/browse/INF-250?atlOrigin=eyJpIjoiY2U4YzU4ZjIzMmMwNDRiMjgwODgzYmRiZTJkMDczYWIiLCJwIjoiaiJ9)