### PR TITLE
[VOTR-119] fix(falsey argument binding): bind falsey arguments to handler params

### DIFF
--- a/ergo/function_invocable.py
+++ b/ergo/function_invocable.py
@@ -133,7 +133,9 @@ class FunctionInvocable:
         for param, default in self._params.items():
             # ergo's canonical name for this param, which the configuration may have a custom mapping for
             ergo_param_name = self.config.args.get(param, param)
-            argument = pydash.get(exposed_data, ergo_param_name) or pydash.get(exposed_data, f"{DATA_KEY}.{ergo_param_name}") or default
+            argument = pydash.get(exposed_data, ergo_param_name, MissingArgument)
+            if argument is MissingArgument:
+                argument = pydash.get(exposed_data, f"{DATA_KEY}.{ergo_param_name}", default)
             # MissingArgument indicates that `param` is a positional parameter that we've failed to bind an argument
             # to, either because no argument was provided or because one was given the wrong name.
             if argument is not MissingArgument:

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.8.10-alpha'
+VERSION = '0.8.11-alpha'
 
 
 def get_version() -> str:

--- a/test/integration/test_amqp/test_argument_binding.py
+++ b/test/integration/test_amqp/test_argument_binding.py
@@ -4,6 +4,24 @@ import pytest
 
 from ergo.context import Context
 
+
+"""
+test_bind_falsey_argument
+
+Assert that ergo will correctly bind a falsey argument to a handler param.
+"""
+
+
+def simple_handler(x):
+    return x
+
+
+def test_bind_falsey_argument():
+    component = AMQPComponent(simple_handler)
+    with component:
+        assert component.rpc({"x": 0}).data is 0
+
+
 """
 These tests assert that ergo can correctly bind message data to a custom parameter using the `args` configuration attribute.
 """


### PR DESCRIPTION
There’s a bug in FunctionInvocable.assemble_arguments that causes it to fail to bind any data that equals False (e.g. 0) to a handler param.