### PR TITLE
generate instance id from current time

### DIFF
--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -146,6 +146,7 @@ class AmqpInvoker(Invoker):
         self._terminating.set()
         self._pending_invocations.acquire(blocking=True, timeout=TERMINATION_GRACE_PERIOD)
         self._component_queue.queue_unbind()
+        self._instance_queue.delete(nowait=True)
         self._connection.close()
         signal.signal(signum, 0)
         signal.raise_signal(signum)

--- a/ergo/util.py
+++ b/ergo/util.py
@@ -1,4 +1,6 @@
 """Convenience Funcs for handling errors, logging, and monitoring."""
+import datetime
+
 import re
 import signal
 import sys
@@ -158,4 +160,4 @@ class defer_termination:
 
 @lru_cache(1)
 def instance_id() -> str:
-    return uniqueid()
+    return datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")

--- a/ergo/util.py
+++ b/ergo/util.py
@@ -1,6 +1,5 @@
 """Convenience Funcs for handling errors, logging, and monitoring."""
 import datetime
-
 import re
 import signal
 import sys

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.8.11-alpha'
+VERSION = '0.8.12-alpha'
 
 
 def get_version() -> str:


### PR DESCRIPTION
This generates the ergo instance ID (and instance queue name) from the current time instead of a random string. This is moderately helpful (for me, right now) for development, by allowing amqp console users to distinguish between component instances and route messages accordingly.