### PR TITLE
fix(ergo graph): detect more ergo configs; fixed overlapping labels by allowing nodes to resize themselves; put topics in boxes

### DIFF
--- a/ergo/schematic.py
+++ b/ergo/schematic.py
@@ -53,10 +53,13 @@ def load_configs(folders: List[str]) -> List[Dict[str, Union[None, str, List[str
     for folder in folders:
         yaml_files = glob.glob(os.path.join(folder, '**/*.y*ml'), recursive=True)
         for yaml_file in yaml_files:
-            if not os.path.basename(yaml_file).startswith('serverless'):
+            if not os.path.basename(yaml_file).startswith('serverless'):  # skip serverless config files
                 with open(yaml_file, 'r', encoding='utf8') as stream:
                     config = yaml.safe_load(stream)
                     if config and 'func' in config:
+                        # example:
+                        # root_folder/api_connector/ship_dc/api_connector.yaml becomes
+                        # api_connector/ship_dc/api_connector
                         component_name = yaml_file[len(os.path.normpath(folder)) + 1:].split('.')[0]
                         config['name'] = component_name
                         configs.append(config)

--- a/ergo/schematic.py
+++ b/ergo/schematic.py
@@ -75,9 +75,9 @@ def topics(dot: graphviz.Digraph, configs: List[Dict[str, Union[None, str, List[
     for config in configs:
         for topic_element in format_topic('pubtopic', config):
             dot.edge(format_component(config)[0], topic_element[0])
-            dot.node(*topic_element)
+            dot.node(*topic_element, shape='box')
         for topic_element in format_topic('subtopic', config):
-            dot.node(*topic_element)
+            dot.node(*topic_element, shape='box')
             dot.edge(topic_element[0], format_component(config)[0])
 
 
@@ -106,7 +106,7 @@ def components(dot: graphviz.Digraph, configs: List[Dict[str, Union[None, str, L
         dot (graphviz.Digraph): Description
         configs (List[Dict[str, Union[None, str, List[str]]]]): Description
     """
-    dot.attr('node', shape='circle', width='1', color='#ffffff80', penwidth='2', fixedsize='true')
+    dot.attr('node', shape='circle', width='1', color='#ffffff80', penwidth='2')
 
     for config in configs:
         dot.node(*format_component(config))

--- a/ergo/schematic.py
+++ b/ergo/schematic.py
@@ -132,7 +132,7 @@ def graph(folders: List[str]) -> None:  # pylint: disable=too-many-branches
     topics(dot, configs)
     derived_topics(dot, configs)
 
-    dot.render('.ergo.gv', format='png', view=True)
+    dot.render('.ergo.gv', view=True)
 
 
 if __name__ == '__main__':

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.8.11-alpha'
+VERSION = '0.8.12-alpha'
 
 
 def get_version() -> str:

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.8.12-alpha'
+VERSION = '0.9.1'
 
 
 def get_version() -> str:


### PR DESCRIPTION
currently `ergo graph` doesn't pick up all ergo configs, and it also has a problem with overflowing label text (screenshot because it generates a pdf):
<img width="1472" alt="image" src="https://user-images.githubusercontent.com/1004527/182206960-b1238308-38f4-43d9-8a24-1aaf1f2e22dc.png">

after this change:
![ergo gv](https://user-images.githubusercontent.com/1004527/182206758-4bdb673b-92b2-4a81-b6e4-90c7a76adba8.png)
