### PR TITLE
ack early

### DIFF
--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -107,6 +107,8 @@ class AmqpInvoker(Invoker):
         # sequentially to guarantee that messages are acknowledged in the order they're received
         with self._handler_lock:
             try:
+                # we acknowledge message receipt eagerly, in order to support long running tasks that
+                # may exceed their broker's `consumer_timeout` setting (30m by default)
                 ack()
                 ergo_message = decodes(body)
                 self._handle_message_inner(ergo_message)

--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -107,10 +107,10 @@ class AmqpInvoker(Invoker):
         # sequentially to guarantee that messages are acknowledged in the order they're received
         with self._handler_lock:
             try:
+                ack()
                 ergo_message = decodes(body)
                 self._handle_message_inner(ergo_message)
             finally:
-                ack()
                 self._pending_invocations.release()
 
     def _handle_message_inner(self, message_in: Message):

--- a/ergo/config.py
+++ b/ergo/config.py
@@ -27,6 +27,7 @@ class Config:
         self._protocol: str = config.get('protocol', 'stack')  # http, amqp, stdio, stack
         self._heartbeat: Optional[str] = config.get('heartbeat')
         self._args: Optional[dict] = config.get('args')
+        self._acks_early: Optional[bool] = config.get('acks_early')
 
     def copy(self):
         return copy.deepcopy(self)
@@ -129,3 +130,7 @@ class Config:
             TYPE: Description
         """
         return int(self._heartbeat) if self._heartbeat else None
+
+    @property
+    def acks_early(self) -> bool:
+        return self._acks_early or False

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.8.11-alpha'
+VERSION = '0.9.0'
 
 
 def get_version() -> str:


### PR DESCRIPTION
Long running components (routes & neptune) need to acknowledge amqp message receipt before they finish, or else they may be disconnected by the broker. As far as I can tell this is the amqp `best practice`, and that components that need to defer acking until they're done should require a flag (as per celery's `acks_late`). 

This also bumps ergo to a non-alpha version. In my experience, requiring components to pin to a patch version of ergo or else install it with an `allow-prereleases` flag has been a hassle with no upside. But if there's a reason to keep this in alpha then I can go back to it.