### PR TITLE
[VOTR-185] autodelete component queues

### DIFF
--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -61,11 +61,12 @@ class AmqpInvoker(Invoker):
         component_queue_name = f"{self._invocable.config.func}".replace("/", ":")
         if component_queue_name.startswith(":"):
             component_queue_name = component_queue_name[1:]
-        self._component_queue = kombu.Queue(name=component_queue_name, exchange=self._exchange, routing_key=str(SubTopic(self._invocable.config.subtopic)), durable=False, channel=self._connection.channel())
+        self._component_queue = kombu.Queue(name=component_queue_name, exchange=self._exchange, routing_key=str(SubTopic(self._invocable.config.subtopic)), durable=False)
         instance_queue_name = f"{component_queue_name}:{instance_id()}"
         self._instance_queue = kombu.Queue(name=instance_queue_name, exchange=self._exchange, routing_key=str(SubTopic(instance_id())), auto_delete=True)
         error_queue_name = f"{component_queue_name}:error"
         self._error_queue = kombu.Queue(name=error_queue_name, exchange=self._exchange, routing_key=error_queue_name, durable=False)
+
         self._terminating = threading.Event()
         self._pending_invocations = threading.Semaphore()
         self._handler_lock = threading.Lock()
@@ -78,12 +79,8 @@ class AmqpInvoker(Invoker):
             consumer: kombu.Consumer = conn.Consumer(queues=[self._component_queue, self._instance_queue], prefetch_count=PREFETCH_COUNT, accept=["json"])
             consumer.register_callback(self._start_handle_message_thread)
             consumer.consume()
-
             while not self._terminating.is_set():
                 try:
-                    # lazy load binding
-                    # to prevent unbinding all consumers w same subtopic at shutdown
-                    self._component_queue.queue_bind(channel=self._connection.channel())
                     # wait up to 1s for the next message before sending a heartbeat
                     conn.drain_events(timeout=1)
                 except socket.timeout:
@@ -149,6 +146,5 @@ class AmqpInvoker(Invoker):
     def _shutdown(self, signum: int, *_: Any) -> None:
         self._terminating.set()
         self._pending_invocations.acquire(blocking=True, timeout=TERMINATION_GRACE_PERIOD)
-        self._component_queue.queue_unbind()
         self._connection.close()
         os.kill(os.getpid(), 0)

--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -61,7 +61,7 @@ class AmqpInvoker(Invoker):
         component_queue_name = f"{self._invocable.config.func}".replace("/", ":")
         if component_queue_name.startswith(":"):
             component_queue_name = component_queue_name[1:]
-        self._component_queue = kombu.Queue(name=component_queue_name, exchange=self._exchange, routing_key=str(SubTopic(self._invocable.config.subtopic)), durable=False)
+        self._component_queue = kombu.Queue(name=component_queue_name, exchange=self._exchange, routing_key=str(SubTopic(self._invocable.config.subtopic)), durable=False, autodelete=True)
         instance_queue_name = f"{component_queue_name}:{instance_id()}"
         self._instance_queue = kombu.Queue(name=instance_queue_name, exchange=self._exchange, routing_key=str(SubTopic(instance_id())), auto_delete=True)
         error_queue_name = f"{component_queue_name}:error"

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.9.2'
+VERSION = '0.10.0'
 
 
 def get_version() -> str:


### PR DESCRIPTION
This PR reverts the changes in https://github.com/nautiluslabsco/ergo/pull/86, which don't seem to be working as intended. That change was recently installed by the routes-generator staging consumers, which have since begun consistently falling into a [connection error loop](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fecs$252Froutes-generator-staging/log-events/ecs$252Froutes$252F626d49602bc443909c2083497c6fe8f8). Meanwhile, the broker is reporting hundreds of consumer bindings on their [component queue](https://b-4578b105-1d2d-4ecf-8f90-63ff45aa4fbc.mq.us-east-1.amazonaws.com/#/queues/%2F/routes%3Ahandler.py%3Agenerate_routes). I don't have a theory for the reverted change could be failing, but I don't see any other commits that could account for it. 

I also added the `auto-delete` flag to the component queue declaration, which should have the same effect.