### PR TITLE
[VOTR-185] fix(tests): fix test flakiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
+            ulimit -n 1024
             make test
             codecov
       - run:
@@ -85,6 +86,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
+            ulimit -n 1024
             make test
             codecov
       - store_artifacts:
@@ -148,23 +150,15 @@ workflows:
       - test-python-install:
           name: test-python-install-3.7
           version: "3.7"
-          requires:
-            - build_verify_lint
       - test-python-install:
           name: test-python-install-3.8
           version: "3.8"
-          requires:
-            - build_verify_lint
       - test-python-install:
           name: test-python-install-3.9
           version: "3.9"
-          requires:
-            - build_verify_lint
       - test-python-install:
           name: test-python-install-3.10
           version: "3.10"
-          requires:
-            - build_verify_lint
       - deploy:
           <<: *release_only
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            ulimit -n 1024
             make test
             codecov
       - run:
@@ -86,7 +85,6 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            ulimit -n 1024
             make test
             codecov
       - store_artifacts:

--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -151,5 +151,4 @@ class AmqpInvoker(Invoker):
         self._pending_invocations.acquire(blocking=True, timeout=TERMINATION_GRACE_PERIOD)
         self._component_queue.queue_unbind()
         self._connection.close()
-        signal.signal(signum, 0)
-        os.kill(os.getpid(), signum)
+        os.kill(os.getpid(), 0)

--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -1,6 +1,7 @@
 """Summary."""
 import datetime
 import logging
+import os
 import signal
 import socket
 import threading
@@ -151,4 +152,4 @@ class AmqpInvoker(Invoker):
         self._component_queue.queue_unbind()
         self._connection.close()
         signal.signal(signum, 0)
-        signal.raise_signal(signum)
+        os.kill(os.getpid(), signum)

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.9.1'
+VERSION = '0.9.2'
 
 
 def get_version() -> str:

--- a/test/integration/utils/__init__.py
+++ b/test/integration/utils/__init__.py
@@ -20,7 +20,7 @@ class ComponentInstance:
         self.process.start()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.process.terminate()
+        self.process.kill()
         self.process.join()
 
 


### PR DESCRIPTION
I'm seeing two potential causes for test flakiness:
1. The test runner is trying to gracefully shutdown ergo subprocs, which tends to timeout for a particular test (`test_fibonacci`) that generates a lot of amqp messages. But there's no reason to be graceful here, since we're tearing everything down anyways.
2. Ergo's amqp consumer shutdown sequence uses a function that was added in python 3.8, which periodically breaks the 3.7 test runner. I replaced it with something 3.7 compatible.