### PR TITLE
feat: TTV-41 expose error information in ergo message

### DIFF
--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -122,6 +122,7 @@ class AmqpInvoker(Invoker):
         except Exception as err:  # pylint: disable=broad-except
             dt = datetime.datetime.now(datetime.timezone.utc)
             message_in.error = make_error_output(err)
+            message_in.extra_error_info = getattr(err, 'extra_error_info', None)
             message_in.traceback = str(err)
             message_in.scope.metadata['timestamp'] = dt.isoformat()
             self._publish(message_in, self._error_queue.name)

--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -41,6 +41,8 @@ def make_error_output(err: Exception) -> Dict[str, str]:
     err_output = {
         'type': type(orig).__name__,
         'message': str(orig),
+        'traceback': str(err),
+        'extra_info': getattr(err, 'extra_info', None),
     }
     filename, lineno, function_name = extract_from_stack(orig)
     if None not in (filename, lineno, function_name):
@@ -122,8 +124,6 @@ class AmqpInvoker(Invoker):
         except Exception as err:  # pylint: disable=broad-except
             dt = datetime.datetime.now(datetime.timezone.utc)
             message_in.error = make_error_output(err)
-            message_in.extra_error_info = getattr(err, 'extra_error_info', None)
-            message_in.traceback = str(err)
             message_in.scope.metadata['timestamp'] = dt.isoformat()
             self._publish(message_in, self._error_queue.name)
             if self._invocable.config.error_pubtopic is not None:

--- a/ergo/function_invocable.py
+++ b/ergo/function_invocable.py
@@ -23,8 +23,6 @@ from ergo.util import instance_id, print_exc_plus
 DATA_KEY = "data"
 CONTEXT_KEY = "context"
 ERROR_KEY = "error"
-EXTRA_ERROR_INFO_KEY = "extra_error_info"
-TRACEBACK_KEY = "traceback"
 
 
 class FunctionInvocable:
@@ -124,8 +122,8 @@ class FunctionInvocable:
 
         except BaseException as invoke_err:
             err = Exception(print_exc_plus())
-            if hasattr(invoke_err, 'extra_error_info'):
-                setattr(err, 'extra_error_info', invoke_err.extra_error_info)
+            if hasattr(invoke_err, 'extra_info'):
+                setattr(err, 'extra_info', invoke_err.extra_info)
             raise err from invoke_err
 
     def assemble_arguments(self, message: Message, context: Context) -> dict:
@@ -139,8 +137,6 @@ class FunctionInvocable:
             CONTEXT_KEY: context,
             DATA_KEY: message.data,
             ERROR_KEY: message.error,
-            EXTRA_ERROR_INFO_KEY: message.extra_error_info,
-            TRACEBACK_KEY: message.traceback,
         }
         for param, default in self._params.items():
             # ergo's canonical name for this param, which the configuration may have a custom mapping for

--- a/ergo/message.py
+++ b/ergo/message.py
@@ -16,6 +16,7 @@ class Message:
     log: List[Any] = field(default_factory=list)
     scope: Scope = field(default_factory=Scope)
     error: Optional[Dict[str, str]] = None
+    extra_error_info: Optional[Dict[str, Any]] = None
     traceback: Optional[str] = None
 
 

--- a/ergo/message.py
+++ b/ergo/message.py
@@ -15,9 +15,7 @@ class Message:
     key: Optional[str] = None
     log: List[Any] = field(default_factory=list)
     scope: Scope = field(default_factory=Scope)
-    error: Optional[Dict[str, str]] = None
-    extra_error_info: Optional[Dict[str, Any]] = None
-    traceback: Optional[str] = None
+    error: Optional[Dict[str, Any]] = None
 
 
 def decodes(s: str) -> Message:

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.11.0'
+VERSION = '0.11.1'
 
 
 def get_version() -> str:

--- a/test/integration/start_rabbitmq_broker.py
+++ b/test/integration/start_rabbitmq_broker.py
@@ -7,12 +7,20 @@ import pika.exceptions
 AMQP_HOST = "amqp://guest:guest@localhost:5672/%2F"
 
 
+def rabbitmq_is_running():
+    try:
+        pika.BlockingConnection(pika.URLParameters(AMQP_HOST))
+        return True
+    except pika.exceptions.AMQPConnectionError:
+        return False
+
+
 def start_rabbitmq_broker():
     """
     Start a rabbitmq server if none is running, and then wait for the broker to finish booting.
     """
     docker_client = docker.from_env()
-    if not docker_client.containers.list(filters={"name": "rabbitmq"}):
+    if not (docker_client.containers.list(filters={"name": "rabbitmq"}) or rabbitmq_is_running()):
         docker_client.containers.run(
             name="rabbitmq",
             image="rabbitmq:3.8.16-management-alpine",
@@ -21,9 +29,9 @@ def start_rabbitmq_broker():
         )
 
     print("awaiting broker")
-    for retry in retries(200, 0.5, pika.exceptions.AMQPConnectionError):
+    for retry in retries(200, 0.5, AssertionError):
         with retry():
-            pika.BlockingConnection(pika.URLParameters(AMQP_HOST))
+            assert rabbitmq_is_running()
     print("broker started")
 
 

--- a/test/integration/test_amqp/test_extra_error_info.py
+++ b/test/integration/test_amqp/test_extra_error_info.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict
+
+from ergo.message import Message
+
+from test.integration.utils.amqp import AMQPComponent, Queue, publish
+
+
+class MyException(Exception):
+    def __init__(self, error_message: str, extra_error_info: Dict[str, Any]):
+        super().__init__(self, error_message)
+        self.extra_error_info = extra_error_info
+
+
+def function_with_error():
+    raise MyException(
+        'my error message',
+        {
+            'int_info': 123,
+            'str_info': 'onetwothree',
+        },
+    )
+
+
+def check_error_message(error_message):
+    assert isinstance(error_message, Message)
+    assert error_message.error['type'] == 'MyException'
+    assert 'my error message' in error_message.error['message']
+    assert error_message.extra_error_info['int_info'] == 123
+    assert error_message.extra_error_info['str_info'] == 'onetwothree'
+
+
+def test_extra_error_info():
+    component = AMQPComponent(function_with_error)
+    error_queue = Queue(name=component.error_queue_name, auto_delete=False)
+    with component, error_queue:
+        publish({}, component.subtopic)
+        error_message = error_queue.get()
+        check_error_message(error_message)
+
+
+def test_extra_error_info_with_error_pubtopic():
+    error_key = 'test.error_pubtopic'
+    component = AMQPComponent(function_with_error, error_pubtopic=error_key)
+    error_queue = Queue(name=component.error_queue_name, auto_delete=False)
+    error_pubtopic = Queue(routing_key=error_key)
+    with component, error_queue, error_pubtopic:
+        publish({}, component.subtopic)
+
+        error_queue_message = error_queue.get()
+        check_error_message(error_queue_message)
+
+        error_pubtopic_message = error_pubtopic.get()
+        check_error_message(error_pubtopic_message)

--- a/test/integration/test_amqp/test_extra_error_info.py
+++ b/test/integration/test_amqp/test_extra_error_info.py
@@ -6,9 +6,9 @@ from test.integration.utils.amqp import AMQPComponent, Queue, publish
 
 
 class MyException(Exception):
-    def __init__(self, error_message: str, extra_error_info: Dict[str, Any]):
+    def __init__(self, error_message: str, extra_info: Dict[str, Any]):
         super().__init__(self, error_message)
-        self.extra_error_info = extra_error_info
+        self.extra_info = extra_info
 
 
 def function_with_error():
@@ -25,8 +25,8 @@ def check_error_message(error_message):
     assert isinstance(error_message, Message)
     assert error_message.error['type'] == 'MyException'
     assert 'my error message' in error_message.error['message']
-    assert error_message.extra_error_info['int_info'] == 123
-    assert error_message.extra_error_info['str_info'] == 'onetwothree'
+    assert error_message.error['extra_info']['int_info'] == 123
+    assert error_message.error['extra_info']['str_info'] == 'onetwothree'
 
 
 def test_extra_error_info():

--- a/test/integration/utils/amqp.py
+++ b/test/integration/utils/amqp.py
@@ -180,7 +180,7 @@ class propagate_errors(contextlib.ContextDecorator):
     def _handle_message(body: str, _):
         ergo_msg = decodes(body)
         if ergo_msg.error:
-            raise ComponentFailure(ergo_msg.traceback)
+            raise ComponentFailure(ergo_msg.error['traceback'])
 
 
 class ComponentFailure(Exception):


### PR DESCRIPTION
this makes error information available to components that consume from error queues

used in https://github.com/nautiluslabsco/qed/pull/749 more specifically https://github.com/nautiluslabsco/nl-qed-util/pull/36