### PR TITLE
chore: added python 3.11 to list of tested versions; linting changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
         type: string
         default: latest
     docker:
-      - image: circleci/python:<< parameters.version >>
+      - image: cimg/python:<< parameters.version >>
       - image: rabbitmq:3.8.16-management-alpine
     steps:
       - checkout
@@ -67,13 +67,13 @@ jobs:
             sudo pip3 install circleci
   integration:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - run: It works!
       - run: echo $RUN_EXTRA_TESTS
   deploy:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - setup_remote_docker:
           version: 19.03.13
       - restore_cache:
-          key: v2-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-<< parameters.version >>-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
       - run:
           name: install python dependencies
           command: |
@@ -49,7 +49,7 @@ jobs:
             . venv/bin/activate
             make dev
       - save_cache:
-          key: v2-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-<< parameters.version >>-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
           paths:
             - "venv"
       - run:
@@ -77,7 +77,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v2-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-<< parameters.version >>-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
       - run:
           name: install python dependencies
           command: |
@@ -85,7 +85,7 @@ jobs:
             . venv/bin/activate
             make dev
       - save_cache:
-          key: v2-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-<< parameters.version >>-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
           paths:
             - "venv"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,8 @@ jobs:
       - run:
           name: install python dependencies
           command: |
-            python3 -m venv venv
+            python -V
+            python -m venv venv
             . venv/bin/activate
             make dev
       - save_cache:
@@ -81,7 +82,7 @@ jobs:
       - run:
           name: install python dependencies
           command: |
-            python3 -m venv venv
+            python -m venv venv
             . venv/bin/activate
             make dev
       - save_cache:
@@ -91,7 +92,7 @@ jobs:
       - run:
           name: verify git tag vs. version
           command: |
-            python3 -m venv venv
+            python -m venv venv
             . venv/bin/activate
             python setup.py verify
       - run: # $PYPI_PASSWORD set in CircleCi > Settings > Environment variables

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           name: Smoke Test Install
           command: |
             python --version
-            sudo pip3 install circleci
+            pip install circleci
   integration:
     docker:
       - image: cimg/python:3.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,11 @@ jobs:
 
   test:
     parameters:
-      version:
+      docker_image:
         type: string
-        default: latest
+        default: cimg/python:3.11.0
     docker:
-      - image: cimg/python:<< parameters.version >>
+      - image: << parameters.docker_image >>
       - image: rabbitmq:3.8.16-management-alpine
     steps:
       - checkout
@@ -45,8 +45,7 @@ jobs:
       - run:
           name: install python dependencies
           command: |
-            python -V
-            python -m venv venv
+            python3 -m venv venv
             . venv/bin/activate
             make dev
       - save_cache:
@@ -68,13 +67,13 @@ jobs:
             sudo pip3 install circleci
   integration:
     docker:
-      - image: cimg/python:3.7
+      - image: circleci/python:3.7
     steps:
       - run: It works!
       - run: echo $RUN_EXTRA_TESTS
   deploy:
     docker:
-      - image: cimg/python:3.7
+      - image: circleci/python:3.7
     steps:
       - checkout
       - restore_cache:
@@ -82,7 +81,7 @@ jobs:
       - run:
           name: install python dependencies
           command: |
-            python -m venv venv
+            python3 -m venv venv
             . venv/bin/activate
             make dev
       - save_cache:
@@ -92,7 +91,7 @@ jobs:
       - run:
           name: verify git tag vs. version
           command: |
-            python -m venv venv
+            python3 -m venv venv
             . venv/bin/activate
             python setup.py verify
       - run: # $PYPI_PASSWORD set in CircleCi > Settings > Environment variables
@@ -119,19 +118,19 @@ workflows:
           <<: *always_run
       - test:
           name: test-python-3.7
-          version: "3.7"
+          docker_image: "circleci/python:3.7"
       - test:
           name: test-python-3.8
-          version: "3.8"
+          docker_image: "circleci/python:3.8"
       - test:
           name: test-python-3.9
-          version: "3.9"
+          docker_image: "circleci/python:3.9"
       - test:
           name: test-python-3.10
-          version: "3.10"
+          docker_image: "circleci/python:3.10"
       - test:
           name: test-python-3.11
-          version: "3.11"
+          docker_image: "cimg/python:3.11"
       - deploy:
           <<: *release_only
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,25 +23,25 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
           pip-dependency-file: dev-requirements.txt
-          cache-version: v1
+          cache-version: v2
       - run:
           name: Lint
           command: make lint
 
   test:
     parameters:
-      docker_image:
+      version:
         type: string
-        default: cimg/python:3.11.0
+        default: latest
     docker:
-      - image: << parameters.docker_image >>
+      - image: cimg/python:<< parameters.version >>
       - image: rabbitmq:3.8.16-management-alpine
     steps:
       - checkout
       - setup_remote_docker:
           version: 19.03.13
       - restore_cache:
-          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
       - run:
           name: install python dependencies
           command: |
@@ -49,7 +49,7 @@ jobs:
             . venv/bin/activate
             make dev
       - save_cache:
-          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
           paths:
             - "venv"
       - run:
@@ -67,17 +67,17 @@ jobs:
             sudo pip3 install circleci
   integration:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - run: It works!
       - run: echo $RUN_EXTRA_TESTS
   deploy:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - restore_cache:
-          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
       - run:
           name: install python dependencies
           command: |
@@ -85,7 +85,7 @@ jobs:
             . venv/bin/activate
             make dev
       - save_cache:
-          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
           paths:
             - "venv"
       - run:
@@ -110,7 +110,6 @@ jobs:
             . venv/bin/activate
             pip install twine
             twine upload dist/*
-
 workflows:
   build_and_deploy:
     jobs:
@@ -118,19 +117,19 @@ workflows:
           <<: *always_run
       - test:
           name: test-python-3.7
-          docker_image: "circleci/python:3.7"
+          version: "3.7"
       - test:
           name: test-python-3.8
-          docker_image: "circleci/python:3.8"
+          version: "3.8"
       - test:
           name: test-python-3.9
-          docker_image: "circleci/python:3.9"
+          version: "3.9"
       - test:
           name: test-python-3.10
-          docker_image: "circleci/python:3.10"
+          version: "3.10"
       - test:
           name: test-python-3.11
-          docker_image: "cimg/python:3.11"
+          version: "3.11"
       - deploy:
           <<: *release_only
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,9 @@ workflows:
       - test:
           name: test-python-3.10
           version: "3.10"
+      - test:
+          name: test-python-3.11
+          version: "3.11"
       - deploy:
           <<: *release_only
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - setup_remote_docker:
           version: 19.03.13
       - restore_cache:
-          key: v2-dependency-cache-<< parameters.version >>-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-<< parameters.version >>-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}-{{ checksum "dev-requirements.txt" }}
       - run:
           name: install python dependencies
           command: |
@@ -49,7 +49,7 @@ jobs:
             . venv/bin/activate
             make dev
       - save_cache:
-          key: v2-dependency-cache-<< parameters.version >>-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-<< parameters.version >>-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}-{{ checksum "dev-requirements.txt" }}
           paths:
             - "venv"
       - run:
@@ -77,7 +77,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v2-dependency-cache-3.7-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-3.7-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}-{{ checksum "dev-requirements.txt" }}
       - run:
           name: install python dependencies
           command: |
@@ -85,7 +85,7 @@ jobs:
             . venv/bin/activate
             make dev
       - save_cache:
-          key: v2-dependency-cache-3.7-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-3.7-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}-{{ checksum "dev-requirements.txt" }}
           paths:
             - "venv"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v2-dependency-cache-<< parameters.version >>-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-3.7-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
       - run:
           name: install python dependencies
           command: |
@@ -85,7 +85,7 @@ jobs:
             . venv/bin/activate
             make dev
       - save_cache:
-          key: v2-dependency-cache-<< parameters.version >>-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v2-dependency-cache-3.7-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
           paths:
             - "venv"
       - run:

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ package:
 	python setup.py bdist_wheel
 
 test:
+	export PYTHONPATH=`pwd`
 	python test/integration/start_rabbitmq_broker.py
 	coverage run --omit src -m pytest -vv --timeout 60
 	coverage html
@@ -30,4 +31,3 @@ fix:
 
 lint:
 	./scripts/lint.sh
-

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export PYTHONPATH := $(shell pwd)
+
 .PHONY: help clean dev docs package test
 
 help:
@@ -21,7 +23,6 @@ package:
 	python setup.py bdist_wheel
 
 test:
-	export PYTHONPATH=`pwd`
 	python test/integration/start_rabbitmq_broker.py
 	coverage run --omit src -m pytest -vv --timeout 60
 	coverage html

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,3 +13,4 @@ docker
 pytest
 pytest-timeout
 importlib-metadata==4.13.0
+pyyaml

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -21,7 +21,7 @@ isort $mod -c
 if [ $? -ne 0 ]; then printf "\e[1mFailed.\e[0m\n" ; exit_code=1; fi; printf "\n"
 
 printf "\e[1mType Checking (mypy) ...\e[0m\n"
-mypy --strict --install-types $mod
+mypy --strict --install-types --non-interactive $mod
 if [ $? -ne 0 ]; then printf "\e[1mFailed.\e[0m\n" ; exit_code=1; fi; printf "\n"
 
 printf "\e[1mComplexity check ...\e[0m\n"

--- a/test/integration/utils/amqp.py
+++ b/test/integration/utils/amqp.py
@@ -34,13 +34,7 @@ class AMQPComponent(FunctionComponent):
     protocol = "amqp"
     instances: List[AMQPComponent] = []
 
-    def __init__(
-        self,
-        func: Callable,
-        subtopic: Optional[str] = None,
-        pubtopic: Optional[str] = None,
-        **manifest
-    ):
+    def __init__(self, func: Callable, subtopic: Optional[str] = None, pubtopic: Optional[str] = None, **manifest):
         super().__init__(func, **manifest)
         self.queue_name = f"{self.handler_path.replace('/', ':')[1:]}:{self.handler_name}"
         self.error_queue_name = f"{self.queue_name}:error"
@@ -118,7 +112,7 @@ def publish(payload: dict, routing_key: str):
             producer.publish(json.dumps(payload), exchange=EXCHANGE, routing_key=str(PubTopic(routing_key)))
 
 
-def await_components(channel: Optional[Channel]=None):
+def await_components(channel: Optional[Channel] = None):
     own_channel = channel is None
     channel = channel or CONNECTION.channel()
     try:

--- a/test/integration/utils/amqp.py
+++ b/test/integration/utils/amqp.py
@@ -11,7 +11,7 @@ import amqp.exceptions
 import kombu
 import kombu.pools
 import kombu.simple
-from amqp import Channel
+from amqp.channel import Channel
 
 from ergo.topic import SubTopic
 


### PR DESCRIPTION
since we want to move to python 3.11, i thought i'd start by running tests in 3.11

circleci/python has been deprecated https://circleci.com/docs/next-gen-migration-guide/ and more importantly they never made a circleci/python:3.11 so i switched to cimg/ and had to update the cache keys and make a few other small changes

i tried to make the linting pass and got it down to only mypy failures... but those are too many and it seems like the whole repo has type errors? in any case that is a project for another day

not updating version because no functional changes