### PR TITLE
chore: removed retry dependency

### DIFF
--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.11.1'
+VERSION = '0.11.2'
 
 
 def get_version() -> str:

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ setup(
         'pyYaml',
         'mypy_extensions',
         'aio-pika',
-        'retry',
         'aiomisc',
         'graphviz',
         'pydash',


### PR DESCRIPTION
while working on https://github.com/nautiluslabsco/pearls/pull/31 for https://github.com/nautiluslabsco/pearls/security/dependabot/3 i discovered that ergo needs retry, which needs py

```
% pip show retry
Name: retry
Version: 0.9.2
Summary: Easy to use retry decorator.
Home-page: https://github.com/invl/retry
Author: invl
Author-email: invlpg@gmail.com
License: Apache License 2.0
Location: /Users/xian/.pyenv/versions/pearls/lib/python3.9/site-packages
Requires: decorator, py
Required-by: ergo
```

but i can't find anywhere that uses retry, so opting to remove it