### PR TITLE
fix: changed autodelete to auto_delete

### DIFF
--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -63,7 +63,7 @@ class AmqpInvoker(Invoker):
         component_queue_name = f"{self._invocable.config.func}".replace("/", ":")
         if component_queue_name.startswith(":"):
             component_queue_name = component_queue_name[1:]
-        self._component_queue = kombu.Queue(name=component_queue_name, exchange=self._exchange, routing_key=str(SubTopic(self._invocable.config.subtopic)), durable=False, autodelete=True)
+        self._component_queue = kombu.Queue(name=component_queue_name, exchange=self._exchange, routing_key=str(SubTopic(self._invocable.config.subtopic)), durable=False, auto_delete=True)
         instance_queue_name = f"{component_queue_name}:{instance_id()}"
         self._instance_queue = kombu.Queue(name=instance_queue_name, exchange=self._exchange, routing_key=str(SubTopic(instance_id())), auto_delete=True)
         error_queue_name = f"{component_queue_name}:error"

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.11.2'
+VERSION = '0.11.3'
 
 
 def get_version() -> str:


### PR DESCRIPTION
the correct spelling seems to be auto_delete

sources:
https://docs.celeryq.dev/projects/kombu/en/stable/reference/kombu.html#queue
https://github.com/nautiluslabsco/ergo/blob/b7805bcf1e411df461197432783eae8ad5cb37aa/ergo/amqp_invoker.py#L68