### PR TITLE
chore: don't auto delete component queue

### DIFF
--- a/ergo/amqp_invoker.py
+++ b/ergo/amqp_invoker.py
@@ -63,7 +63,7 @@ class AmqpInvoker(Invoker):
         component_queue_name = f"{self._invocable.config.func}".replace("/", ":")
         if component_queue_name.startswith(":"):
             component_queue_name = component_queue_name[1:]
-        self._component_queue = kombu.Queue(name=component_queue_name, exchange=self._exchange, routing_key=str(SubTopic(self._invocable.config.subtopic)), durable=False, auto_delete=True)
+        self._component_queue = kombu.Queue(name=component_queue_name, exchange=self._exchange, routing_key=str(SubTopic(self._invocable.config.subtopic)), durable=False)
         instance_queue_name = f"{component_queue_name}:{instance_id()}"
         self._instance_queue = kombu.Queue(name=instance_queue_name, exchange=self._exchange, routing_key=str(SubTopic(instance_id())), auto_delete=True)
         error_queue_name = f"{component_queue_name}:error"

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.11.4'
+VERSION = '0.12.0'
 
 
 def get_version() -> str:

--- a/ergo/version.py
+++ b/ergo/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.11.3'
+VERSION = '0.11.4'
 
 
 def get_version() -> str:


### PR DESCRIPTION
in https://github.com/nautiluslabsco/ergo/pull/107 i fixed a typo and set component queues to auto delete 

but after using that a bit, i have changed my mind; reasoning below

firstly, according to [the documentation](https://www.rabbitmq.com/queues.html#:~:text=An%20auto%2Ddelete%20queue%20will,TCP%20connection%20with%20the%20server), if so configured, these queues will be deleted when the consumer disconnects... i could not find anything on the internet that says the queue has to be empty... so it deletes the queue even if it's not empty, as long as the consumer has disconnected

also it's difficult to update an existing component to ergo 0.11.3 because:
* queue already exists
* we upgrade to 0.11.3 and deploy
* we try to recreate the queue with auto delete
* this fails because there is already an existing queue with the same name, but without auto delete
* we have to manually delete the queue and start the component, which will recreate the queue with auto delete

on the other hand, if this pr is approved, going to 0.11.4 will be easy because 0.11.3 queues will be auto deleted when the component shuts down for deploy, so there will be no problem recreating them without auto delete

instance queues remain auto delete, which i think is correct: https://github.com/nautiluslabsco/ergo/blob/34644265371a0d12b0292dd65cd0b893b423e626/ergo/amqp_invoker.py#L68