### PR TITLE
chore: try to resolve current test failures by running with sudo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            make test
+            sudo -E make test
             codecov
       - store_artifacts:
           path: htmlcov/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            sudo -E make test
+            make test
             codecov
       - store_artifacts:
           path: htmlcov/

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ package:
 
 test:
 	python test/integration/start_rabbitmq_broker.py
-	sudo -E env PATH=$PATH coverage run --omit src -m pytest -vv --timeout 60
+	sudo -E env PATH=${PATH} coverage run --omit src -m pytest -vv --timeout 60
 	coverage html
 
 fix:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ package:
 
 test:
 	python test/integration/start_rabbitmq_broker.py
-	sudo -E coverage run --omit src -m pytest -vv --timeout 60
+	sudo -E env PATH=$PATH coverage run --omit src -m pytest -vv --timeout 60
 	coverage html
 
 fix:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ package:
 
 test:
 	python test/integration/start_rabbitmq_broker.py
-	coverage run --omit src -m pytest -vv --timeout 60
+	sudo -E coverage run --omit src -m pytest -vv --timeout 60
 	coverage html
 
 fix:
@@ -30,4 +30,3 @@ fix:
 
 lint:
 	./scripts/lint.sh
-


### PR DESCRIPTION
in https://github.com/nautiluslabsco/ergo/pull/108 unrelated tests which passed last time are now failing

digging deeper, we see failures that look like
```
  File "/home/circleci/project/venv/lib/python3.10/site-packages/hypercorn/config.py", line 261, in _create_sockets
    sock.bind(binding)
PermissionError: [Errno 13] Permission denied
```

it is trying to use localhost port 80, so maybe there was a policy change in circleci to no longer allow that... this pr runs the test with sudo to get around that

references:
https://stackoverflow.com/questions/8633461/how-to-keep-environment-variables-when-using-sudo
https://askubuntu.com/questions/234758/how-to-use-a-python-virtualenv-with-sudo
https://stackoverflow.com/questions/28890634/how-to-get-a-shell-environment-variable-in-a-makefile