### PR TITLE
chore: GEN-232 added default context to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ always_run: &always_run
       only: /.*/
 
 release_only: &release_only
+  context: default-context
   filters:
     tags:
       only: /[0-9]+(\.[0-9]+)*/


### PR DESCRIPTION
following up on https://github.com/nautiluslabsco/ergo/pull/110

i thought it was already configured to use this context because it is named default context, but it wasn't

copied from https://github.com/nautiluslabsco/nlpy/blob/88446fdc1758727b31ff688e9e33cf8edf2a2939/.circleci/config.yml#L7