### PR TITLE
feat(dependencies): Unpin jinja2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         'jsons',
         'quart',
         'kombu',
-        'jinja2>=3.0,<3.1',  # 3.1.0 removes jinja2.escape, which Quart implicitly requires as of 2022/03/25
+        'jinja2',  # 3.1.0 removes jinja2.escape, which Quart implicitly requires as of 2022/03/25
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',  # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         'jsons',
         'quart',
         'kombu',
-        'jinja2',  # 3.1.0 removes jinja2.escape, which Quart implicitly requires as of 2022/03/25
+        'jinja2',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',  # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package


### PR DESCRIPTION
I'm attempting to resolve a [dependency conflict in this build](https://app.circleci.com/pipelines/github/nautiluslabsco/neptune/575/workflows/b088db77-43e8-42e1-9f5f-c7825f83c7ae/jobs/935). I couldn't find it in Quart, but I'm assuming they've matured past their state in Mar 2022.

I have no idea how to test this other than merging and releasing, updating the dep in `neptune`, then re-running that build.